### PR TITLE
Fix link to `sup-choo` in `readme.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Learn `choo` through a set of exercises:
 
 ## Contents
-- [sup-choo]()
+- [sup-choo](sup-choo.md)
 - [concepts]()
 - [views]()
 


### PR DESCRIPTION
While forking saw that none of the links were working; undoubtedly because it’s not done yet.

But anyway, here’s that one link fix! :)
