### PR TITLE
fixing 'standard' linting problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var css = require('sheetify')
 var path = require('path')
 var choo = require('choo')
 
-
 ;css('tachyons')
 ;css('vhs/css/vhs.css')
 ;css('highlight-syntax-pastel')


### PR DESCRIPTION
it expects only one line of whitespace, while there are two.

Now the errors that are being thrown are from `standard-markdown`, and no longer from `standard`