### PR TITLE
Fix `sentence` example output

### DIFF
--- a/content/your-first-choo-app/README.md
+++ b/content/your-first-choo-app/README.md
@@ -273,6 +273,8 @@ sentence()
 
 // the following is logged to screen:
 // "Yay! Alice is having fun!"
+// "Yay! Alice is having fun!"
+// "Yay! Alice is having fun!"
 ```
 
 As mentioned earlier in this guide:

--- a/src/your-first-choo-app/index.html
+++ b/src/your-first-choo-app/index.html
@@ -217,6 +217,8 @@ sentence()
 
 // the following is logged to screen:
 // &quot;Yay! Alice is having fun!&quot;
+// &quot;Yay! Alice is having fun!&quot;
+// &quot;Yay! Alice is having fun!&quot;
 </code></pre>
 <p>As mentioned earlier in this guide:</p>
 <p><em>&quot;Templates are essentially functions: given some input, they will render a new output depending on what happens inside that function.&quot;</em></p>


### PR DESCRIPTION
Per #91, this fixes the output of calling the `sentence` example function.